### PR TITLE
chore: add GitHub CI workflows and dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/05-camel-integration-capability/employee-backend"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "ai.wanaku*"
+      - dependency-name: "org.apache.camel*"
+
+  - package-ecosystem: "maven"
+    directory: "/06-camel-integration-capability-existing-route/sample-routes"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "ai.wanaku*"
+      - dependency-name: "org.apache.camel*"
+
+  - package-ecosystem: "maven"
+    directory: "/06-code-execution-engine/tax-advisor-agent"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "ai.wanaku*"
+      - dependency-name: "org.apache.camel*"
+
+  - package-ecosystem: "maven"
+    directory: "/06-sample-auth-based-mcp"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "ai.wanaku*"
+      - dependency-name: "org.apache.camel*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -1,0 +1,53 @@
+name: Build Main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - .github/**
+      - README.md
+      - LICENSE
+      - index.md
+
+env:
+  PROJECTS: ${{ github.workspace }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Checkout Wanaku Capabilities SDK
+      uses: actions/checkout@v4
+      with:
+        repository: wanaku-ai/wanaku-capabilities-java-sdk
+        persist-credentials: false
+        ref: main
+        path: wanaku-capabilities-java-sdk
+    - name: Build Wanaku Capabilities SDK
+      run: mvn -DskipTests clean install
+      working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
+    - name: Build employee-backend
+      run: mvn -B package --file pom.xml
+      working-directory: ${{ github.workspace }}/05-camel-integration-capability/employee-backend
+    - name: Build sample-routes
+      run: mvn -B package --file pom.xml
+      working-directory: ${{ github.workspace }}/06-camel-integration-capability-existing-route/sample-routes
+    - name: Build tax-advisor-agent
+      run: mvn -B package --file pom.xml
+      working-directory: ${{ github.workspace }}/06-code-execution-engine/tax-advisor-agent
+    - name: Build sample-auth-based-mcp
+      run: mvn -B package --file pom.xml
+      working-directory: ${{ github.workspace }}/06-sample-auth-based-mcp

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -1,0 +1,58 @@
+name: PR Builds
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - .github/**
+      - README.md
+      - LICENSE
+      - index.md
+
+env:
+  PROJECTS: ${{ github.workspace }}
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        experimental: [false]
+        include:
+          - os: [windows-latest]
+            experimental: true
+      fail-fast: true
+
+    steps:
+    - name: Checkout Wanaku Capabilities SDK
+      uses: actions/checkout@v4
+      with:
+        repository: wanaku-ai/wanaku-capabilities-java-sdk
+        persist-credentials: false
+        ref: main
+        path: wanaku-capabilities-java-sdk
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build Wanaku Capabilities SDK
+      run: mvn -DskipTests clean install
+      working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
+    - uses: actions/checkout@v4
+    - name: Build employee-backend
+      run: mvn -B package --file pom.xml
+      working-directory: ${{ github.workspace }}/05-camel-integration-capability/employee-backend
+    - name: Build sample-routes
+      run: mvn -B package --file pom.xml
+      working-directory: ${{ github.workspace }}/06-camel-integration-capability-existing-route/sample-routes
+    - name: Build tax-advisor-agent
+      run: mvn -B package --file pom.xml
+      working-directory: ${{ github.workspace }}/06-code-execution-engine/tax-advisor-agent
+    - name: Build sample-auth-based-mcp
+      run: mvn -B package --file pom.xml
+      working-directory: ${{ github.workspace }}/06-sample-auth-based-mcp


### PR DESCRIPTION
## Summary
- Add main branch build workflow that builds all Maven subprojects on push to main
- Add PR build workflow with multi-platform matrix (Linux, macOS, Windows experimental)
- Add dependabot configuration for Maven dependencies and GitHub Actions, excluding Wanaku and Camel dependencies from automated updates
- Both CI workflows checkout and build wanaku-capabilities-java-sdk first since several demos depend on it