### PR TITLE
Update demos for Wanaku 0.1.0 consistency

### DIFF
--- a/04-plain-java-services/README.md
+++ b/04-plain-java-services/README.md
@@ -21,12 +21,12 @@ First, generate a new capability project using the Wanaku SDK's Maven archetype.
 mvn -B archetype:generate \
     -DarchetypeGroupId=ai.wanaku.sdk \
     -DarchetypeArtifactId=capabilities-archetypes-java-tool \
-    -DarchetypeVersion=0.0.7 \
+    -DarchetypeVersion=0.1.0 \
     -DgroupId=net.orpiske \
     -Dpackage=net.orpiske \
     -DartifactId=echo \
     -Dname=EchoService \
-    -Dwanaku-sdk-version=0.0.7
+    -Dwanaku-sdk-version=0.1.0
 ```
 
 > [IMPORTANT]
@@ -82,46 +82,9 @@ public void invokeTool(ToolInvokeRequest request, StreamObserver<ToolInvokeReply
 
 ## 📦 3. Packaging the Application
 
-To package our application into a single, executable JAR file, we need to add the `maven-assembly-plugin` to the `pom.xml`.
+The archetype already includes the `maven-assembly-plugin` configuration, so packaging is straightforward.
 
-Add the following `<build>` section inside the `<project>` tag in your `pom.xml`:
-
-```xml
-<build>
-    <plugins>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.7.1</version>
-            <configuration>
-                <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-                <archive>
-                    <manifest>
-                        <mainClass>net.orpiske.App</mainClass>
-                    </manifest>
-                </archive>
-                <finalName>echo-app</finalName>
-                <appendAssemblyId>false</appendAssemblyId>
-            </configuration>
-            <executions>
-                <execution>
-                    <id>make-assembly</id>
-                    <phase>package</phase>
-                    <goals>
-                        <goal>single</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
-    </plugins>
-</build>
-```
-
-**Note:** After Wanaku version `0.0.8`, this plugin configuration will be included in the archetype by default, so this step will no longer be necessary.
-
-Now, build the project again to create the executable JAR.
+Build the project to create the executable JAR:
 
 ```shell
 mvn clean package
@@ -145,7 +108,7 @@ Let's launch the service and test it with Wanaku.
 
     ```shell
     # Example using Podman
-    podman run -d -p 8080:8080 quay.io/wanaku/wanaku-router:wanaku-0.0.7
+    podman run -d -p 8080:8080 quay.io/wanaku/wanaku-router-backend:0.1.0
     ```
 
 3.  **Set the Environment Variable** Export the `MCP_ECHO` variable with a test value.

--- a/06-camel-integration-capability-existing-route/sample-routes/camel-core-examples/cat-facts-example/pom.xml
+++ b/06-camel-integration-capability-existing-route/sample-routes/camel-core-examples/cat-facts-example/pom.xml
@@ -83,7 +83,7 @@
                 <dependency>
                     <groupId>ai.wanaku.sdk</groupId>
                     <artifactId>capabilities-runtime-camel-plugin</artifactId>
-                    <version>0.1.0-SNAPSHOT</version>
+                    <version>0.1.0</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/06-camel-integration-capability-existing-route/sample-routes/camel-jbang-examples/cat-facts-jbang-example/README.md
+++ b/06-camel-integration-capability-existing-route/sample-routes/camel-jbang-examples/cat-facts-jbang-example/README.md
@@ -49,7 +49,7 @@ export CLIENT_SECRET=<secret>
 ### Run with Camel JBang
 
 ```bash
-camel run --dep ai.wanaku.sdk:capabilities-runtime-camel-plugin:0.1.0-SNAPSHOT cat-facts-route.camel.yaml
+camel run --dep ai.wanaku.sdk:capabilities-runtime-camel-plugin:0.1.0 cat-facts-route.camel.yaml
 ```
 
 ## MCP Tool

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ one, then check the table below.
 
 | Version                                                              |
 |----------------------------------------------------------------------|
+| [0.1.0](https://github.com/wanaku-ai/wanaku-demos/tree/wanaku-0.1.0) |
 | [0.0.7](https://github.com/wanaku-ai/wanaku-demos/tree/wanaku-0.0.7) |
 | [0.0.6](https://github.com/wanaku-ai/wanaku-demos/tree/wanaku-0.0.6) |
 | [0.0.5](https://github.com/wanaku-ai/wanaku-demos/tree/wanaku-0.0.5) |

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ hero:
 
   actions:
     - theme: brand
-      text: Gtting Started Guide (Using Docker Compose)
+      text: Getting Started Guide (Using Docker Compose)
       link: ./01-getting-started/README
 
 features:
@@ -20,4 +20,10 @@ features:
   - title: Building a Plain Java Capability for Wanaku
     details: This guide will walk you through creating a simple "echo" capability for Wanaku using Java with the Java Capabilities SDK
     link: ./04-plain-java-services/README
+  - title: Camel Integration Capability
+    details: Run Apache Camel workloads on Wanaku using the Camel Integration Capability
+    link: ./05-camel-integration-capability/README
+  - title: Exposing Existing Camel Routes with Wanaku
+    details: Learn how to expose existing Apache Camel routes as MCP tools via the Wanaku plugin
+    link: ./06-camel-integration-capability-existing-route/sample-routes/camel-core-examples/cat-facts-example/README
 ---


### PR DESCRIPTION
## Summary
- Add 0.1.0 to the released versions table in README.md
- Fix "Gtting" typo in index.md and add entries for demos 05 and 06
- Update 04-plain-java-services: SDK archetype 0.0.7 → 0.1.0, router image → `wanaku-router-backend:0.1.0`, remove obsolete assembly plugin section (now included in archetype)
- Update 06-camel-integration-capability-existing-route: `capabilities-runtime-camel-plugin` 0.1.0-SNAPSHOT → 0.1.0

## Test plan
- [ ] Verify 04-plain-java-services archetype generation works with `0.1.0`
- [ ] Verify 06 cat-facts-example builds with released `0.1.0` plugin
- [ ] Verify index.md renders correctly with new entries