### PR TITLE
Pin container images to 0.1.1 in Wanaku on the Cloud guide

### DIFF
--- a/02-wanaku-on-the-cloud/README.md
+++ b/02-wanaku-on-the-cloud/README.md
@@ -235,7 +235,7 @@ spec:
     authServer: http://<KEYCLOAK_HOST>
     authProxy: "auto"
   router:
-    image: quay.io/wanaku/wanaku-router-backend:latest
+    image: quay.io/wanaku/wanaku-router-backend:0.1.1
     imagePullPolicy: Always
 ```
 
@@ -271,7 +271,7 @@ spec:
   routerRef: wanaku-router
   capabilities:
     - name: wanaku-http
-      image: quay.io/wanaku/wanaku-tool-service-http:latest
+      image: quay.io/wanaku/wanaku-tool-service-http:0.1.1
 ```
 
 Apply it:


### PR DESCRIPTION
## Summary
- Replaces `:latest` with `:0.1.1` for the router and HTTP capability images in the 02-wanaku-on-the-cloud guide

## Test plan
- [ ] Verify the pinned images match the 0.1.1 release on quay.io