### PR TITLE
chore: replace UI instructions with CLI commands in 2.03

### DIFF
--- a/2.03-service-templates/README.md
+++ b/2.03-service-templates/README.md
@@ -9,38 +9,29 @@ Service Templates are reusable, parameterized blueprints for creating Service Ca
 
 ## Part 1: Using a Built-in Template
 
-### Step 1: Browse Available Templates
+### Step 1: List Available Templates
 
-Open the Wanaku Admin UI at <http://localhost:8080/admin/#/service-catalog> and click the
-**Service Templates** tab. You should see templates like:
+```shell
+wanaku service template list
+```
 
-- `kafka-tool`
-- `jms-tool`
-- `github-pullrequest-source-tool`
-- `mail-sink-tool`
-- `rabbitmq-tool`
+You should see templates like `kafka-tool`, `jms-tool`, `github-pullrequest-source-tool`,
+`mail-sink-tool`, `rabbitmq-tool`, among others. Each entry shows the template name, description,
+and the properties it requires.
 
-### Step 2: View Template Details
+### Step 2: Instantiate the Template
 
-Click on the **kafka-tool** template to expand it. You will see its description and the list of
-required properties (broker address, topics, timeout, etc.).
+Instantiate the `kafka-tool` template, passing the required properties as comma-separated
+key=value pairs:
 
-### Step 3: Instantiate the Template
+```shell
+wanaku service template instantiate --name=kafka-tool \
+  --properties=kafka.brokers=localhost:9092,kafka.request.topic=ai.requests,kafka.response.topic=ai.responses,kafka.reply.timeout-ms=30000,kafka.response.group-id=wanaku-demo-group
+```
 
-Click **Instantiate** on the `kafka-tool` template. Fill in the properties:
+The instantiated catalog is automatically deployed to the router.
 
-| Property                       | Value                  |
-|--------------------------------|------------------------|
-| `kafka.brokers`                | `localhost:9092`       |
-| `kafka.request.topic`         | `ai.requests`          |
-| `kafka.response.topic`        | `ai.responses`         |
-| `kafka.reply.timeout-ms`      | `30000`                |
-| `kafka.response.group-id`     | `wanaku-demo-group`    |
-
-Give it a name (e.g., `kafka-demo`) and click **Deploy**. The instantiated catalog is automatically
-deployed.
-
-### Step 4: Verify
+### Step 3: Verify
 
 ```shell
 wanaku tools list | grep kafka
@@ -127,18 +118,15 @@ wanaku service template deploy --file=weather-template.zip --host=http://localho
 
 ### Step 7: Instantiate Your Template
 
-Open the **Service Templates** tab in the Admin UI at <http://localhost:8080/admin/#/service-catalog>.
-Find `weather-template`, click **Instantiate**, and fill in the properties:
+Instantiate the template you just deployed, providing the required property values:
 
-| Property              | Value                        |
-|-----------------------|------------------------------|
-| `weather.api.key`     | Your OpenWeatherMap API key  |
-| `weather.location`    | `New York`                   |
-| `weather.units`       | `metric`                     |
-
-Give it a name (e.g., `my-weather-service`) and click **Deploy**.
+```shell
+wanaku service template instantiate --name=weather-template \
+  --properties=weather.api.key=YOUR_API_KEY,weather.location=New\ York,weather.units=metric
+```
 
 > **Note:** You'll need a free API key from [OpenWeatherMap](https://openweathermap.org/api) to use this template.
+> Replace `YOUR_API_KEY` with your actual key.
 
 ## What's Next?
 
@@ -149,7 +137,7 @@ Give it a name (e.g., `my-weather-service`) and click **Deploy**.
 ### Template instantiation fails with "missing property"
 
 - Double-check property names match exactly (case-sensitive)
-- Ensure all required properties are provided via `--property` flags
+- Ensure all required properties are provided via the `--properties` flag
 - Check the template's `service.properties` file for required placeholders
 
 If you find a bug, please [report it](https://github.com/wanaku-ai/wanaku/issues).

--- a/2.03-service-templates/README.md
+++ b/2.03-service-templates/README.md
@@ -21,17 +21,49 @@ and the properties it requires.
 
 ### Step 2: Instantiate the Template
 
-Instantiate the `kafka-tool` template, passing the required properties as comma-separated
-key=value pairs:
+Instantiate the `kafka-tool` template, passing the required properties:
 
 ```shell
 wanaku service template instantiate --name=kafka-tool \
-  --properties=kafka.brokers=localhost:9092,kafka.request.topic=ai.requests,kafka.response.topic=ai.responses,kafka.reply.timeout-ms=30000,kafka.response.group-id=wanaku-demo-group
+  --property=kafka.brokers=localhost:9092 \
+  --property=kafka.request.topic=ai.requests \
+  --property=kafka.response.topic=ai.responses \
+  --property=kafka.reply.timeout-ms=30000 \
+  --property=kafka.response.group-id=wanaku-demo-group
 ```
 
-The instantiated catalog is automatically deployed to the router.
+### Step 3: Deploy the Instantiated Catalog
 
-### Step 3: Verify
+Get the deployment instructions for the instantiated catalog:
+
+```shell
+wanaku service instructions --name kafka-tool --model local
+```
+
+This prints the command to launch the Camel Integration Capability. The output looks like:
+
+```text
+Deployment instructions for 'kafka-tool' (camel-integration-capability, local)
+
+
+--- System: kafka ---
+
+java -jar camel-integration-capability-main-*-jar-with-dependencies.jar \
+--registration-url <registration-url> \
+--registration-announce-address localhost \
+--grpc-port <grpc-port> \
+--name kafka \
+--service-catalog kafka-tool \
+--service-catalog-system kafka \
+--client-id wanaku-service \
+--fail-fast
+```
+
+Run that command in a separate terminal, filling in the placeholders. See the
+[Introduction to Capabilities](../2.01-introduction-to-capabilities/README.md) guide for
+details on downloading and running the Camel Integration Capability.
+
+### Step 4: Verify
 
 ```shell
 wanaku tools list | grep kafka
@@ -122,7 +154,9 @@ Instantiate the template you just deployed, providing the required property valu
 
 ```shell
 wanaku service template instantiate --name=weather-template \
-  --properties=weather.api.key=YOUR_API_KEY,weather.location=New\ York,weather.units=metric
+  --property=weather.api.key=YOUR_API_KEY \
+  --property=weather.location="New York" \
+  --property=weather.units=metric
 ```
 
 > **Note:** You'll need a free API key from [OpenWeatherMap](https://openweathermap.org/api) to use this template.
@@ -137,7 +171,7 @@ wanaku service template instantiate --name=weather-template \
 ### Template instantiation fails with "missing property"
 
 - Double-check property names match exactly (case-sensitive)
-- Ensure all required properties are provided via the `--properties` flag
+- Ensure all required properties are provided via `--property` flags
 - Check the template's `service.properties` file for required placeholders
 
 If you find a bug, please [report it](https://github.com/wanaku-ai/wanaku/issues).


### PR DESCRIPTION
## Summary

- Replaced UI-based template browsing, instantiation, and deployment steps with CLI equivalents (`wanaku service template list`, `wanaku service template instantiate`)
- Consolidated Part 1 from 4 steps to 3 (merged browse/view into a single `list` step)
- Updated Part 2 Step 7 to use CLI instantiation instead of the Admin UI
- Fixed troubleshooting section to reference `--properties` flag (was `--property`)

## Test plan

- [ ] Verify `wanaku service template list` output matches the described templates
- [ ] Verify `wanaku service template instantiate --name=kafka-tool --properties=...` works end-to-end
- [ ] Verify weather template instantiation command works with a real API key