### PR TITLE
Add SEO frontmatter to demo READMEs

### DIFF
--- a/1.00-understanding-mcp-and-wanaku/README.md
+++ b/1.00-understanding-mcp-and-wanaku/README.md
@@ -1,3 +1,8 @@
+---
+title: "Understanding MCP and Wanaku"
+description: "Learn the concepts behind the Model Context Protocol and how Wanaku extends it with routing, namespaces, and forwarding."
+---
+
 # Understanding MCP and Wanaku
 
 Welcome to the Wanaku demo series. Before writing any commands, this guide explains the concepts behind the Model Context Protocol (MCP) and how Wanaku fits into the picture.

--- a/1.01-your-first-tool/README.md
+++ b/1.01-your-first-tool/README.md
@@ -1,3 +1,8 @@
+---
+title: "Your First Wanaku Tool"
+description: "Install the Wanaku CLI, start a local instance, add a tool, and call it from an AI agent."
+---
+
 # Getting Started with Wanaku
 
 Welcome to Wanaku! In this guide you will install the Wanaku CLI, start a local instance, add a tool, and

--- a/1.02-basic-wanaku-operations/README.md
+++ b/1.02-basic-wanaku-operations/README.md
@@ -1,3 +1,8 @@
+---
+title: "Basic Wanaku Operations"
+description: "Manage tools, resources, prompts, and forwards — the four core MCP primitives in Wanaku."
+---
+
 # Managing Tools, Resources, Prompts, and Forwards
 
 You have Wanaku running. You imported your first tool. Now what? This guide walks you through the day-to-day operations: adding, listing, inspecting, and removing the four core primitives that Wanaku orchestrates.

--- a/2.01-introduction-to-capabilities/README.md
+++ b/2.01-introduction-to-capabilities/README.md
@@ -1,3 +1,8 @@
+---
+title: "Introduction to Capabilities"
+description: "Understand how capabilities work in Wanaku — built-in HTTP, Exec, and the Camel Integration Capability."
+---
+
 # Introduction to Capabilities
 
 This guide explains what capabilities are in Wanaku, how they work, and what ships out-of-the-box versus what you can extend.

--- a/2.02-service-catalogs/README.md
+++ b/2.02-service-catalogs/README.md
@@ -1,3 +1,8 @@
+---
+title: "Service Catalogs"
+description: "Package Apache Camel routes as MCP tools and deploy them to the Wanaku MCP Router."
+---
+
 # Service Catalogs Demo
 
 This demo walks you through creating and deploying a Service Catalog — a way to package Apache Camel routes as tools that AI agents can use through Wanaku.

--- a/2.03-service-templates/README.md
+++ b/2.03-service-templates/README.md
@@ -1,3 +1,8 @@
+---
+title: "Service Templates"
+description: "Use reusable, parameterized blueprints to create Wanaku Service Catalogs quickly."
+---
+
 # Service Templates Demo
 
 Service Templates are reusable, parameterized blueprints for creating Service Catalogs. Instead of writing Camel routes from scratch, you pick a template, fill in the parameters, and deploy. This demo shows how to use built-in templates and create your own.

--- a/3.01-wanaku-on-the-cloud/README.md
+++ b/3.01-wanaku-on-the-cloud/README.md
@@ -1,3 +1,8 @@
+---
+title: "Wanaku on the Cloud"
+description: "Deploy Wanaku on OpenShift or Kubernetes with Keycloak authentication and the Wanaku Operator."
+---
+
 # Wanaku on the Cloud
 
 This guide walks you through deploying Wanaku on OpenShift (or Kubernetes) in a production-like configuration. By the end, you will have:

--- a/3.02-camel-integration-capability/README.md
+++ b/3.02-camel-integration-capability/README.md
@@ -1,3 +1,8 @@
+---
+title: "Camel Integration Capability"
+description: "Run Apache Camel workloads on Wanaku using the Camel Integration Capability."
+---
+
 # Camel Integration Capability
 
 Enterprise systems don't speak MCP. Your HR database, your inventory API, your

--- a/4.01-plain-java-capability/README.md
+++ b/4.01-plain-java-capability/README.md
@@ -1,3 +1,8 @@
+---
+title: "Building a Plain Java Capability"
+description: "Create a custom echo capability for the Wanaku MCP Router using the Java Capabilities SDK."
+---
+
 # Building a Java Capability for Wanaku
 
 This guide will walk you through creating a simple "echo" capability for Wanaku using Java. 

--- a/4.02-exposing-existing-routes/sample-routes/camel-core-examples/cat-facts-example/README.md
+++ b/4.02-exposing-existing-routes/sample-routes/camel-core-examples/cat-facts-example/README.md
@@ -1,3 +1,8 @@
+---
+title: "Exposing Camel Routes (Core)"
+description: "Expose existing Apache Camel core routes as MCP tools via the Wanaku plugin."
+---
+
 # Cat Facts Example
 
 A pure Java Apache Camel application that fetches random cat facts, demonstrating integration with the Wanaku Camel Integration Capability plugin.

--- a/4.02-exposing-existing-routes/sample-routes/camel-jbang-examples/cat-facts-jbang-example/README.md
+++ b/4.02-exposing-existing-routes/sample-routes/camel-jbang-examples/cat-facts-jbang-example/README.md
@@ -1,3 +1,8 @@
+---
+title: "Exposing Camel Routes (JBang)"
+description: "Expose Apache Camel JBang routes as MCP tools via the Wanaku plugin."
+---
+
 # Cat Facts JBang Example
 
 A Camel JBang application using YAML DSL that fetches random cat facts, demonstrating integration with the Wanaku Camel Integration Capability plugin.

--- a/5.01-camel-assistant/README.md
+++ b/5.01-camel-assistant/README.md
@@ -1,3 +1,8 @@
+---
+title: "Camel Assistant on OpenShift"
+description: "Build an expert AI assistant for Apache Camel using LangFlow, RAG, and the Wanaku MCP Router."
+---
+
 # Wanaku + Camel Assistant on OpenShift
 
 This guide walks you through deploying a specialized Apache Camel assistant on OpenShift. It uses Retrieval-Augmented Generation (RAG) backed by a Camel dataset, Wanaku MCP Router as the tool provider, and LangFlow as the visual AI designer.


### PR DESCRIPTION
## Summary
- Add `title` and `description` YAML frontmatter to all 12 demo READMEs
- Enables VitePress to generate proper `<title>` and `<meta name="description">` tags for each demo page

## Test plan
- [ ] Build the website with `make docs` and verify demo pages have unique titles and descriptions in built HTML