### PR TITLE
chore: add demos 2.04 and 2.05 to the features menu in the index

### DIFF
--- a/index.md
+++ b/index.md
@@ -29,6 +29,12 @@ features:
   - title: "Chapter 2: Service Templates"
     details: Use reusable, parameterized blueprints to create Service Catalogs quickly
     link: ./2.03-service-templates/README
+  - title: "Chapter 2: Organizing with Namespaces"
+    details: Use Wanaku namespaces to isolate tools and resources across environments or teams
+    link: ./2.04-organizing-with-namespaces/README
+  - title: "Chapter 2: Aggregating MCP Servers with Forwards"
+    details: Expose tools from upstream MCP servers through a single Wanaku router endpoint using forwards
+    link: ./2.05-aggregating-mcp-servers-with-forwards/README
   - title: "Chapter 3: Wanaku on the Cloud"
     details: Deploy Wanaku on OpenShift with Keycloak authentication and the Wanaku Operator
     link: ./3.01-wanaku-on-the-cloud/README


### PR DESCRIPTION
## Summary

- Adds demo 2.04 (Organizing with Namespaces) and demo 2.05 (Aggregating MCP Servers with Forwards) to the index page features list
- Placed between Chapter 2 (Service Templates) and Chapter 3 (Wanaku on the Cloud)

Depends on #47 and #48 for the actual demo content.