### PR TITLE
docs: Add descriptive alt text to images for improved SEO and accessibility

### DIFF
--- a/1.01-your-first-tool/README.md
+++ b/1.01-your-first-tool/README.md
@@ -168,7 +168,7 @@ Then ask it a question like:
 
 > How much is 100 USD in CZK?
 
-![Claude call example](claude-call.png)
+![Screenshot of Claude Desktop successfully calling the Wanaku currency conversion tool to convert 100 USD to CZK, showing the AI agent's response with the exchange rate result](claude-call.png)
 
 ## What's Next?
 

--- a/2.02-service-catalogs/README.md
+++ b/2.02-service-catalogs/README.md
@@ -245,7 +245,7 @@ Try invoking `get-book-by-isbn` with:
 
 The tool should return details for *Camel in Action* from the Open Library API.
 
-![MCP Inspector — get-book-by-isbn result](imgs/get-by-isbn.png)
+![Screenshot of MCP Inspector showing the successful result of calling the get-book-by-isbn tool with ISBN 9781935182368, displaying book details for 'Camel in Action' retrieved from the Open Library API](imgs/get-by-isbn.png)
 
 You can also try `search-books`:
 
@@ -255,7 +255,7 @@ You can also try `search-books`:
 }
 ```
 
-![MCP Inspector — search-books result](imgs/search.png)
+![Screenshot of MCP Inspector showing the successful result of calling the search-books tool with query 'Camel In Action', displaying a list of matching books from the Open Library API with their titles, authors, and publication information](imgs/search.png)
 
 ## What's Next?
 


### PR DESCRIPTION
## Summary

This PR improves SEO and accessibility by adding descriptive alt text to all images in the documentation.

## Changes

- Added detailed alt text to  in the Getting Started guide
- Added detailed alt text to  and  in the Service Catalogs guide

## Benefits

- **SEO**: Search engines can better understand and index image content
- **Accessibility**: Screen readers can describe images to visually impaired users
- **Context**: Users with slow connections or disabled images get meaningful descriptions

## Testing

- Verified all image references still work correctly
- Confirmed alt text is descriptive and contextual

This is part of a larger SEO improvement initiative for the Wanaku documentation site.